### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/examples/lights.py
+++ b/examples/lights.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import time
+import signal
+
+import automationhat
+
+automationhat.enable_auto_lights(False)
+
+automationhat.light.on()
+
+for analog in automationhat.analog:
+    analog.light.on()
+
+for output in automationhat.output:
+    output.light.on()
+
+for input in automationhat.input:
+    input.light.on()
+
+signal.pause()

--- a/library/automationhat/__init__.py
+++ b/library/automationhat/__init__.py
@@ -1,5 +1,6 @@
 import atexit
 import time
+import warnings
 from sys import version_info
 
 try:
@@ -35,17 +36,9 @@ automation_phat = True
 
 _led_states = [0] * 18
 _lights_need_updating = False
-_warnings = True
 _is_setup = False
 _t_update_lights = None
 
-def _warn(message):
-    if _warnings:
-        print("Warning: {}\nDisable this message with automationhat.set_warnings(False)".format(message))
-
-def set_warnings(mode):
-    global _warnings
-    _warnings = mode
 
 class SNLight(object):
     def __init__(self, index):
@@ -121,7 +114,7 @@ class AnalogInput(object):
     def read(self):
         """Return the read voltage of the analog input"""
         if self.name == "four" and is_automation_phat():
-            _warn("Analog Four is not supported on Automation pHAT")
+            warnings.warn("Analog Four is not supported on Automation pHAT")
 
         self._update()
         return round(self.value * self.max_voltage, 2)
@@ -280,7 +273,7 @@ class Relay(Output):
         self.setup()
 
         if is_automation_phat() and self.name in ["two", "three"]:
-            _warn("Relay '{}' is not supported on Automation pHAT".format(self.name))
+            warnings.warn("Relay '{}' is not supported on Automation pHAT".format(self.name))
 
         GPIO.output(self.pin, value)
 

--- a/library/automationhat/__init__.py
+++ b/library/automationhat/__init__.py
@@ -47,50 +47,44 @@ _led_dirty = False
 _is_setup = False
 
 
-class Default():
+class Default(object):
     """Stand-in for ObjectCollection used to ensure one-time setup.
 
     """
 
     def __init__(self, parent_name=None, **kwargs):
+        object.__init__(self)
         self._parent_name = parent_name
-        self._parent = None
 
     def _ensure_setup(self):
-        setup()
-        self._parent = globals()[self._parent_name]
+        if not _is_setup:
+            setup()
+        self._ensure_setup = lambda: globals()[self._parent_name]
+        return globals()[self._parent_name]
 
     def __iter__(self):
-        self._ensure_setup()
-        return self._parent.__iter__()
+        return self._ensure_setup().__iter__()
 
     def __call__(self):
-        self._ensure_setup()
-        return self._parent.__call__()
+        return self._ensure_setup().__call__()
 
     def __repr__(self):
-        self._ensure_setup()
-        return self._parent.__repr__()
-
-    def __str__(self):
-        self._ensure_setup()
-        return self._parent.__str__()
+        return self._ensure_setup().__repr__()
 
     def __len__(self):
-        self._ensure_setup()
-        return self._parent.__len__()
+        return self._ensure_setup().__len__()
 
     def __dir__(self):
-        self._ensure_setup()
-        return self._parent.__dir__()
+        return self._ensure_setup().__dir__()
 
-    def __getattr__(self, name):
-        self._ensure_setup()
-        return self._parent.__getattr__(name)
+    def __getattribute__(self, name):
+        if name in ("_parent_name", "_ensure_setup"):
+            return object.__getattribute__(self, name)
+
+        return self._ensure_setup().__getattr__(name)
 
     def __getitem__(self, key):
-        self._ensure_setup()
-        return self._parent.__getitem__(key)
+        return self._ensure_setup().__getitem__(key)
 
 
 class SNLight(object):

--- a/library/automationhat/__init__.py
+++ b/library/automationhat/__init__.py
@@ -33,6 +33,15 @@ i2c = None
 
 _led_states = [0] * 18
 _led_dirty = False
+_warnings = True
+
+def _warn(message):
+    if _warnings:
+        print("Warning: {}\nDisable this message with automationhat.set_warnings(False)".format(message))
+
+def set_warnings(mode):
+    global _warnings
+    _warnings = mode
 
 class SNLight(object):
     def __init__(self, index):
@@ -101,6 +110,9 @@ class AnalogInput(object):
 
     def read(self):
         """Return the read voltage of the analog input"""
+        if self.name == "four" and is_automation_phat():
+            _warn("Analog Four is not supported on Automation pHAT")
+
         return round(self.value * self.max_voltage, 2)
 
     def _update(self):
@@ -232,7 +244,7 @@ class Relay(Output):
 
         _setup_gpio()
 
-        if is_automation_phat():
+        if is_automation_phat() and self.name == "one":
             self.pin = RELAY_3
 
         GPIO.setup(self.pin, GPIO.OUT, initial=0)
@@ -245,6 +257,10 @@ class Relay(Output):
         :param value: Value to write, either 0 for LOW or 1 for HIGH
         """
         self.setup()
+
+        if is_automation_phat() and self.name in ["two", "three"]:
+            _warn("Relay '{}' is not supported on Automation pHAT".format(self.name))
+
         GPIO.output(self.pin, value)
 
         if value:


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Automation HAT library:

* Do not perform any module setup on import
* Do not output any messages/text on import
* Use ImportError instead of hard exit() for "friendly" import error messages

An experimental `Default` class, which shadows all the methods used in Automation HATs `ObjectCollection` class is used to trap calls to the library and call `ensure_setup` before handing them off to the correct class.

The default class is triggered only once. After this default class has been triggered, it will be replaced by instances of the actual Relay, Input, Output, etc classes for subsequent calls.

The `setup` method will be called automatically by the first call to an Automation HAT method. It will raise a `RuntimeError` if run again. If you want to `setup` with custom settings - ie: `quiet` mode - then `automationhat.setup()` should be the first thing you call after import.

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488