### PR TITLE
Do not add analog input four on Automation pHAT to avoid warnings

### DIFF
--- a/library/automationhat/__init__.py
+++ b/library/automationhat/__init__.py
@@ -388,7 +388,8 @@ analog = ObjectCollection()
 analog._add(one=AnalogInput(0, 25.85, 0))
 analog._add(two=AnalogInput(1, 25.85, 1))
 analog._add(three=AnalogInput(2, 25.85, 2))
-analog._add(four=AnalogInput(3, 3.3, None))
+if (is_automation_hat()):
+  analog._add(four=AnalogInput(3, 3.3, None))
 
 input = ObjectCollection()
 input._add(one=Input(INPUT_1, 14))


### PR DESCRIPTION
To avoid problems on using `automationhat.analog.read()` when on an Automation pHAT, do only initiate analog input four when on a HAT.

I had problems with the `node-red-contrib-automation-hat` module always disconnecting/connecting because of these error messages and think it's good to solve this at the root.