### PR TITLE
Fix race condition with ADC reads.

### DIFF
--- a/library/automationhat/ads1015.py
+++ b/library/automationhat/ads1015.py
@@ -1,5 +1,16 @@
+from functools import wraps
+from threading import Lock
 import time
 import sys
+
+def synchronized(func):
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with self._lock:
+            return func(self, *args, **kwargs)
+
+    return wrapper
 
 ADDR = 0x48
 
@@ -26,7 +37,9 @@ class ads1015:
             raise TypeError("Object given for i2c_bus must implement write_i2c_block_data and read_i2c_block_data")
 
         self.addr = addr
+        self._lock = Lock()
 
+    @synchronized
     def read(self, channel=0, programmable_gain=PGA_4_096V, samples_per_second=1600):
         # sane defaults
         config = 0x0003 | 0x0100


### PR DESCRIPTION
I've noticed that sometimes a read() from one ADC will return a value that seemed to originate from another ADC. 

To reproduce, using AutomationHat with 12V DC connected to ADC 1 and 5V DC connected to ADC 2, run the following script. It will randomly print out values around 12V (which it shouldn't, since all read values should be close to 5 V):

```
import automationhat

while True:
	u = automationhat.analog.two.read()
	if u > 5.05:
		print(u)
```

I believe this happens because of a race condition between ADC reads from the _update_lights() function, which runs in a separate thread, and ADC reads in the main thread. The ads1015.read() is not thread-safe, since only one thread at a time can talk on the i2c bus.

This pull request adds a lock on read() that synchronizes accesses to the ADC. I believe this change should fix the problem. With the patch applied the test script above no longer prints out wrong readings.