### PR TITLE
Fix deprecation warning in Python 3.7

### DIFF
--- a/library/automationhat/pins.py
+++ b/library/automationhat/pins.py
@@ -12,12 +12,12 @@ class StoppableThread(threading.Thread):
         self.daemon = True
 
     def start(self):
-        if not self.isAlive():
+        if not self.is_alive():
             self.stop_event.clear()
             threading.Thread.start(self)
 
     def stop(self):
-        if self.isAlive():
+        if self.is_alive():
             self.stop_event.set()
             self.join()
 


### PR DESCRIPTION
Starting with Python 3.7 the automationhat library triggered the following
warning:
"PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead"

This commit replaces usage of the deprecated Thread.isAlive() function with
is_alive(), which was introduced in Python 2.6.