### PR TITLE
Analog output, round to 3 decimal places. Add explanation to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 [![PyPi Package](https://img.shields.io/pypi/v/automationhat.svg)](https://pypi.python.org/pypi/automationhat)
 [![Python Versions](https://img.shields.io/pypi/pyversions/automationhat.svg)](https://pypi.python.org/pypi/automationhat)
 
-
-https://shop.pimoroni.com/products/automation-hat
-https://shop.pimoroni.com/products/automation-phat
-
 Automation HAT/pHAT is a home monitoring and automation controller featuring relays, analog channels, powered outputs, and buffered inputs (all 24V tolerant).
+
+### Where to buy
+
+* Pimoroni Automation HAT <https://shop.pimoroni.com/products/automation-hat>
+* Pimoroni Automation pHAT <https://shop.pimoroni.com/products/automation-phat>
 
 ## Installing
 
-### Full install (recommended):
+### Full install (recommended)
 
 We've created an easy installation script that will install all pre-requisites and get your Automation HAT/pHAT
 up and running with minimal efforts. To run it, fire up Terminal which you'll find in Menu -> Accessories -> Terminal
@@ -32,13 +33,14 @@ Alternatively, on Raspbian, you can download the `pimoroni-dashboard` and instal
 ```bash
 sudo apt-get install pimoroni
 ```
+
 (you will find the Dashboard under 'Accessories' too, in the Pi menu - or just run `pimoroni-dashboard` at the command line)
 
 If you choose to download examples you'll find them in `/home/pi/Pimoroni/automationhat/`.
 
-### Manual install:
+### Manual install
 
-#### Library install for Python 3:
+#### Library install for Python 3
 
 on Raspbian:
 
@@ -52,7 +54,7 @@ other environments:
 sudo pip3 install automationhat
 ```
 
-#### Library install for Python 2:
+#### Library install for Python 2
 
 on Raspbian:
 
@@ -66,26 +68,35 @@ other environments:
 sudo pip2 install automationhat
 ```
 
-### Development:
+### Development
 
 If you want to contribute, or like living on the edge of your seat by having the latest code, you should clone this repository, `cd` to the library directory, and run:
 
 ```bash
 sudo python3 setup.py install
 ```
+
 (or `sudo python setup.py install` whichever your primary Python environment may be)
 
 In all cases you will have to enable the i2c bus.
 
 ## Documentation & Support
 
-* Guides and tutorials
-https://learn.pimoroni.com/automation-hat
-https://learn.pimoroni.com/automation-phat
+* Guides and tutorials:
+  * Automation HAT <https://learn.pimoroni.com/automation-hat>
+  * Automation pHAT <https://learn.pimoroni.com/automation-phat>
 * Function reference
-https://github.com/pimoroni/automation-hat/tree/master/documentation
-* GPIO Pinout
-https://pinout.xyz/pinout/automation_hat
-https://pinout.xyz/pinout/automation_phat
+<https://github.com/pimoroni/automation-hat/tree/master/documentation>
+* GPIO Pinout:
+  * Automation HAT: <https://pinout.xyz/pinout/automation_hat>
+  * Automation pHAT: <https://pinout.xyz/pinout/automation_phat>
 * Get help
-http://forums.pimoroni.com/c/support
+<http://forums.pimoroni.com/c/support>
+
+### FAQ
+
+#### What is the accuracy and resolution of the Automation HAT
+
+The ADS1015 is a 12-bit ADC, but the 12th bit is the sign-bit so positive voltages between 0 and 24v (actually 25.85v because of how the resistor divider is set up) so it's closer to 0.012v granularity.
+
+Except the full-scale range of the ADC when reading a 0-25.85v value is actually set to 4.096v (not 3.3v) giving only ~1649 possible usable values, which brings us to a granularity of 0.015v (25.85 / 1649) for 24v and 0.002v for the 3.3v inputs. More information on this topic can be found here: <https://forums.pimoroni.com/t/automation-hat-accuracy/7252/3>

--- a/library/automationhat/__init__.py
+++ b/library/automationhat/__init__.py
@@ -117,7 +117,7 @@ class AnalogInput(object):
             warnings.warn("Analog Four is not supported on Automation pHAT")
 
         self._update()
-        return round(self.value * self.max_voltage, 2)
+        return round(self.value * self.max_voltage, 3)
 
     def _update(self):
         self.setup()


### PR DESCRIPTION
Changing rounding of Analog readings from 2 decimal places to 3, in order to reflect the accuracy and resolution of the ADC on the Automation HAT. (Fixes: #25)

The README has also been updated with an additional FAQ section which explains more about the reason why the 12-bit ADC doesn't provide 4096 possible values.

Some minor markdown style fixes have also been applied.