### PR TITLE
Add support for ADS1115

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.4, 3.5, 3.7, 3.8]
+        python: [2.7, 3.5, 3.7, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
         working-directory: library
         run: |
           python -m pip install coveralls
-          coveralls
-        if: ${{ matrix.python == '3.8' }}
+          coveralls --service=github
+        if: ${{ matrix.python == '3.9' }}
 

--- a/examples/hat/analog.py
+++ b/examples/hat/analog.py
@@ -11,6 +11,7 @@ Press CTRL+C to exit.
 """)
 
 while True:
-    value = automationhat.analog.one.read()
-    print(value)
-    time.sleep(0.25)
+    one = automationhat.analog.one.read()
+    two = automationhat.analog.two.read()
+    print(one, two)
+    time.sleep(0.5)

--- a/library/automationhat/ads1015.py
+++ b/library/automationhat/ads1015.py
@@ -18,6 +18,7 @@ ADDR = 0x48
 REG_CONV = 0x00
 REG_CFG = 0x01
 
+# Only accurate for ADS1015
 SAMPLES_PER_SECOND_MAP = {128: 0x0000, 250: 0x0020, 490: 0x0040, 920: 0x0060, 1600: 0x0080, 2400: 0x00A0, 3300: 0x00C0}
 CHANNEL_MAP = {0: 0x4000, 1: 0x5000, 2: 0x6000, 3: 0x7000}
 PROGRAMMABLE_GAIN_MAP = {6144: 0x0000, 4096: 0x0200, 2048: 0x0400, 1024: 0x0600, 512: 0x0800, 256: 0x0A00}
@@ -41,9 +42,17 @@ class ads1015:
         self.addr = addr
         self._lock = Lock()
 
+    def busy(self):
+        data = self.i2c_bus.read_i2c_block_data(self.addr, REG_CFG)
+        status = (data[0] << 8) | data[1]
+        return (status & (1 << 15)) == 0
+
     @synchronized
-    def read(self, channel=0, programmable_gain=PGA_4_096V, samples_per_second=1600):
+    def read(self, channel=0):
         """Read a single ADC channel."""
+        programmable_gain = PGA_4_096V
+        samples_per_second = 250
+
         # sane defaults
         config = 0x0003 | 0x0100
 
@@ -54,22 +63,45 @@ class ads1015:
         # set "single shot" mode
         config |= 0x8000
 
-        delay = (1.0 / samples_per_second) + 0.0001
-
         # write single conversion flag
-
         self.i2c_bus.write_i2c_block_data(self.addr, REG_CFG, [(config >> 8) & 0xFF, config & 0xFF])
-        time.sleep(delay)
+
+        # Time the ADC conversion to disambiguate ADS1015 from ADS1115
+        # Genius out of the box thinking by Niko
+        # the ADS1015 will run this at 250SPS
+        # the ADS1115 will run this at 16!!! SPS
+        # Since the difference is ~an order of magnitude~ they're easy to tell apart.
+        t_start = time.time()
+
+        while self.busy():
+            # We've got a lock on the I2S bus, but probably don't want to hog it!
+            time.sleep(1.0 / 160)
+
+        t_end = time.time()
+        t_elapsed = t_end - t_start
+
         data = self.i2c_bus.read_i2c_block_data(self.addr, REG_CONV)
 
-        value = ((data[0] << 4) | (data[1] >> 4))
+        if t_elapsed < 1.0 / 16: # 1/16th second is ADS1115 speed, if it's faster it must be an ADS1015
+            # 12-bit
+            value = (data[0] << 4) | (data[1] >> 4)
 
-        if value & 0x800:
-            value -= 1 << 12
+            if value & 0x800:  # Check and apply sign bit
+                value -= 1 << 12
 
-        value /= 2047.0  # Divide down to percentage of FS
-        value *= float(programmable_gain)
-        value /= 3300.0  # Divide by VCC
+            value /= 2047.0  # Divide by full scale range
+
+        else: # If it's slower than "ideal" ADS1115 then it's an ADS1115
+            # 16-bit
+            value = (data[0] << 8) | data[1]
+
+            if value & 0x8000:  # Check and apply sign bit
+                value -= 1 << 16
+
+            value /= 32767.0  # Divide by full scale rane
+
+        value *= float(programmable_gain)  # Multiply by gain 
+        value /= 3300.0  # Divide by supply voltage
 
         return value
 
@@ -85,3 +117,4 @@ class ads1015:
             return True
         except IOError:
             return False
+

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -1,0 +1,59 @@
+import sys
+import mock
+import pytest
+
+
+class MockSMBus():
+    def __init__(self, bus):
+        self.regs = {
+            0x48: [0 for _ in range(255)],  # ads1015,
+            0x54: [0 for _ in range(255)]   # sn3218
+        }
+        self.regs[0x48][0] = (1 << 11) - 1  # 12-bit ADC, 12th bit is sign
+
+        # Set the uppermost bit of the ADS1015 CONFIG register
+        # to indicate an "inactive/start" status
+        self.regs[0x48][1] = 0b10000000
+
+    def read_i2c_block_data(self, address, register, length=2):
+        if (address, register) == (0x48, 0):
+            value = self.regs[address][register:register+(length // 2)]
+            return [(value[0] >> 4) & 0xff, (value[0] & 0x0f) << 4]
+        return self.regs[address][register:register+length]
+
+    def write_i2c_block_data(self, address, register, data):
+        if (address, register) == (0x48, 1):
+            return 0
+        self.regs[address][register:register+len(data)] = data
+
+
+@pytest.fixture(scope='function')
+def smbus_notimeout():
+    sys.modules['smbus'] = mock.Mock()
+    sys.modules['smbus'].SMBus = MockSMBus
+    yield
+    del sys.modules['smbus']
+
+
+@pytest.fixture(scope='function')
+def smbus_timeout():
+    sys.modules['smbus'] = mock.Mock()
+    sys.modules['smbus'].SMBus = MockSMBus
+    yield
+    del sys.modules['smbus']
+
+
+@pytest.fixture(scope='function')
+def mocksmbus():
+    sys.modules['smbus'] = mock.Mock()
+    yield sys.modules['smbus']
+    del sys.modules['smbus']
+
+
+@pytest.fixture(scope='function')
+def gpio():
+    sys.modules['RPi'] = mock.Mock()
+    sys.modules['RPi.GPIO'] = mock.MagicMock()
+    yield
+    del sys.modules['RPi']
+    del sys.modules['RPi.GPIO']

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -2,38 +2,12 @@ import mock
 import sys
 
 
-class MockSMBus():
-    def __init__(self, bus):
-        self.regs = {
-            0x48: [0 for _ in range(255)],  # ads1015,
-            0x54: [0 for _ in range(255)]   # sn3218
-        }
-        self.regs[0x48][0] = (1 << 11) - 1  # 12-bit ADC, 12th bit is sign
-
-    def read_i2c_block_data(self, address, register, length=2):
-        if address == 0x48:
-            value = self.regs[address][register:register+(length // 2)]
-            return [(value[0] >> 4) & 0xff, (value[0] & 0x0f) << 4]
-        return self.regs[address][register:register+length]
-
-    def write_i2c_block_data(self, address, register, data):
-        self.regs[address][register:register+len(data)] = data
-
-
-def test_setup():
-    sys.modules['smbus'] = mock.Mock()
-    sys.modules['smbus'].SMBus = MockSMBus
-    sys.modules['RPi'] = mock.Mock()
-    sys.modules['RPi.GPIO'] = mock.MagicMock()
+def test_setup(gpio, smbus_notimeout):
     import automationhat
     automationhat.setup()
 
 
-def test_analog():
-    sys.modules['smbus'] = mock.Mock()
-    sys.modules['smbus'].SMBus = MockSMBus
-    sys.modules['RPi'] = mock.Mock()
-    sys.modules['RPi.GPIO'] = mock.MagicMock()
+def test_analog(smbus_notimeout):
     import automationhat
     # VCC = 3.3, GAIN = 4.096, FS = 2.027, Max Voltage = 25.85
     # output ~= ((1 << 11) - 1) / 2047.0 * 2096.0 / 3300.0 * 25.85


### PR DESCRIPTION
Add transparent support for ADS1115 by measuring the conversion time.

The ADS1115 is a slower, 16-bit version of the 12-bit ADS1015.

Since ADS1115 is roughly 16x slower than ADS1105 with the same settings, we can detect which chip our measurements are coming from an compensate accordingly.

Thanks to Niko for this - somewhat jokey - stroke of genius.