### PR TITLE
Fix SN3218 2.0.0 bug for #50

### DIFF
--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >= 2.7
 packages = automationhat
 install_requires =
     RPi.GPIO
-    sn3218
+    sn3218>=2.0.0
     ST7735
     ads1015>=0.0.8
 


### PR DESCRIPTION
The breaking update to v2.0.0 in SN3218 messed up the phat/hat disambiguation and SN3218 auto detection. I've updated to the new class-based approach to fix this.