### PR TITLE
Update build include list in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,7 @@ path = "automationhat/__init__.py"
 
 [tool.hatch.build]
 include = [
-    "automationhat",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE"
+    "automationhat"
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
Removed unnecessary files from the build inclusion list. A wheel should not contain a top-level files because it gets installed in .../site-packages/